### PR TITLE
Abstract TestSuite and empty files crashes xunit

### DIFF
--- a/core/src/Runners/TestSuiteLoader.ts
+++ b/core/src/Runners/TestSuiteLoader.ts
@@ -10,12 +10,15 @@ export default class TestSuiteLoader {
 	static async loadTestSuite(file: string, filters: RegExp[]) {
 		const module_path = TestSuiteLoader.getModulePath(__dirname, file);
 		const test_class = await import(module_path);
-		if (!(test_class.default.prototype instanceof TestSuite)) {
+
+		// The test suite must be the default export of the imported module
+		if (!(test_class.default?.prototype instanceof TestSuite)) {
 			return null;
 		}
 
+		// The prototype can still be an abstract class, which means getTest() will return undefined
 		const tests = test_class.default.prototype.getTests(filters);
-		if (Object.keys(tests).length === 0) {
+		if (!tests || Object.keys(tests).length === 0) {
 			return null;
 		}
 

--- a/core/tests/Framework/TestAbstractTestSuite.ts
+++ b/core/tests/Framework/TestAbstractTestSuite.ts
@@ -1,0 +1,3 @@
+import { TestSuite } from "../../xunit";
+
+export default abstract class AbstractTestSuiteTests extends TestSuite {}

--- a/core/tests/Framework/TestNoDefaultExport.ts
+++ b/core/tests/Framework/TestNoDefaultExport.ts
@@ -1,0 +1,3 @@
+import { TestSuite } from "../../xunit";
+
+export class NoDefaultExportTestSuiteTests extends TestSuite {}

--- a/core/tests/Framework/TestNoTestSuite.ts
+++ b/core/tests/Framework/TestNoTestSuite.ts
@@ -1,0 +1,2 @@
+const hello = "Hello world!";
+export default hello;


### PR DESCRIPTION
Added tests exposing a bugs where files with no default export and files with an abstract TestSuite crashes xunit. Fixed the bugs in the code by adding more checks to the test suite loader.